### PR TITLE
fix off-by one in simulation of PUSH

### DIFF
--- a/Scripts/simulator.js
+++ b/Scripts/simulator.js
@@ -562,7 +562,7 @@ app.service('simulator', [function () {
         switch(R){
           case 0:
 
-          for (var i = ArrayLength ; i >= 0; i--) {
+          for (var i = ArrayLength-1 ; i >= 0; i--) {
             // Memory[SP] = RListArray[i];
             scope.memory.storeWord(scope.sp,scope.regs[RListArray[i]]);
             scope.sp-=4;
@@ -571,7 +571,7 @@ app.service('simulator', [function () {
 
           break;
           case 1:
-          for (var i = ArrayLength; i >= 0; i--) {
+          for (var i = ArrayLength-1; i >= 0; i--) {
              scope.memory.storeWord(scope.sp,scope.regs[RListArray[i]]);
              scope.sp-=4;
           }


### PR DESCRIPTION
The loop range in the simulation of PUSH was started with the argument array length as first index, which leads to an extra push of a non-existent register and subsequently the SP is off by -4.

Correct the starting index to be (arraylength-1), which is the maximum index for 0-based array indexing.

Minimal example to reproduce at https://bkhmsi.github.io/ARMThumb_Sim/#/

```asm
.code 
bl test
swi 6 

test: 
	mov r1,#0xf1
	mov r2,#0xf2
	push {r1,r2 ; decrements SP by 12
	pop {r1,r2} ; increments SP by 8  
	bx lr
```